### PR TITLE
Updated with correct policy name.

### DIFF
--- a/Remediation scripts/Just-In-Time network access control should be applied on virtual machines/Logic App/Enable-JIT.json
+++ b/Remediation scripts/Just-In-Time network access control should be applied on virtual machines/Logic App/Enable-JIT.json
@@ -110,7 +110,7 @@
                                                     {
                                                         "equals": [
                                                             "@items('For_each_2')?['properties']?['securityTaskParameters']?['policyName']",
-                                                            "Apply a Just-In-Time network access control"
+                                                            "Just-In-Time network access control should be applied on virtual machines"
                                                         ]
                                                     }
                                                 ]

--- a/Remediation scripts/Just-In-Time network access control should be applied on virtual machines/Powershell/Enable-JIT.ps1
+++ b/Remediation scripts/Just-In-Time network access control should be applied on virtual machines/Powershell/Enable-JIT.ps1
@@ -55,7 +55,7 @@ $Subscriptions = Get-AzSubscription
 foreach($Subscription in $Subscriptions){
     $Id = ($Subscription.Id)
     Select-AzSubscription $Id
-    $SecurityTasks += Get-AzSecurityTask | Where-Object {$_.RecommendationType -eq "Apply a Just-In-Time network access control"}
+    $SecurityTasks += Get-AzSecurityTask | Where-Object {$_.RecommendationType -eq "Just-In-Time network access control should be applied on virtual machines"}
 }
 
 # Enable JIT


### PR DESCRIPTION
The current implementation looks for the policy name: Apply a Just-In-Time network access control which doesn't exist. The correct policy is: Just-In-Time network access control should be applied on virtual machines.

PS. Restarted the PR due to major changes in the base repo.
