### PR TITLE
Uses parameters instead of Read-Host

### DIFF
--- a/Remediation scripts/Customize Endpoint Protection Recommendation/Modules/EndPointProtectionDSC/AzureGuestConfigurationPolicy/AzureGuestPolicyHelper.psm1
+++ b/Remediation scripts/Customize Endpoint Protection Recommendation/Modules/EndPointProtectionDSC/AzureGuestConfigurationPolicy/AzureGuestPolicyHelper.psm1
@@ -1,13 +1,27 @@
 function New-EPDSCAzureGuestConfigurationPolicyPackage
 {
     [CmdletBinding()]
-    param()
-
-    $ResourceGroupName     = Read-Host "Resource Group Name"
-    $ResourceGroupLocation = Read-Host "Location"
-    $storageContainerName  = Read-Host "Storage Container Name"
-    $storageAccountName    = Read-Host "Storage Account Name"
-    $storageSKUName        = Read-Host "Storage SKU Name"
+    param
+    (
+        [Parameter(Mandatory = $true,
+                   HelpMessage = '[string] Resource Group Name')]
+        [ValidateNotNullOrEmpty()]
+        [string]$ResourceGroupName,
+        [Parameter(Mandatory = $false,
+                   HelpMessage = '[string] Location')]
+        [string]$ResourceGroupLocation,
+        [Parameter(Mandatory = $true,
+                   HelpMessage = '[string] Storage Container Name')]
+        [ValidateNotNullOrEmpty()]
+        [string]$storageContainerName,
+        [Parameter(Mandatory = $true,
+                   HelpMessage = '[string] Storage Account Name')]
+        [ValidateNotNullOrEmpty()]
+        [string]$storageAccountName,
+        [Parameter(Mandatory = $false,
+                   HelpMessage = '[string] Storage SKU Name')]
+        [string]$storageSKUName
+    )
 
     if ([System.String]::IsNullOrEmpty($storageSKUName))
     {

--- a/Remediation scripts/Customize Endpoint Protection Recommendation/Modules/EndPointProtectionDSC/AzureGuestConfigurationPolicy/AzureGuestPolicyHelper.psm1
+++ b/Remediation scripts/Customize Endpoint Protection Recommendation/Modules/EndPointProtectionDSC/AzureGuestConfigurationPolicy/AzureGuestPolicyHelper.psm1
@@ -38,7 +38,7 @@ function New-EPDSCAzureGuestConfigurationPolicyPackage
         $numberedSubscriptions | Format-Table
 
         $subNumber = Read-Host "Select No"
-        Set-AzContext $numberedSubscriptions[$subNumber-1].Name
+        Set-AzContext $numberedSubscriptions[$subNumber-1].Name | Out-Null
     }
     
     Write-Host "Done" -ForegroundColor Green

--- a/Remediation scripts/Customize Endpoint Protection Recommendation/Modules/EndPointProtectionDSC/AzureGuestConfigurationPolicy/AzureGuestPolicyHelper.psm1
+++ b/Remediation scripts/Customize Endpoint Protection Recommendation/Modules/EndPointProtectionDSC/AzureGuestConfigurationPolicy/AzureGuestPolicyHelper.psm1
@@ -9,7 +9,7 @@ function New-EPDSCAzureGuestConfigurationPolicyPackage
         [string]$ResourceGroupName,
         [Parameter(Mandatory = $false,
                    HelpMessage = '[string] Location')]
-        [string]$ResourceGroupLocation,
+        [string]$ResourceGroupLocation = 'eastus',
         [Parameter(Mandatory = $true,
                    HelpMessage = '[string] Storage Container Name')]
         [ValidateNotNullOrEmpty()]
@@ -20,18 +20,8 @@ function New-EPDSCAzureGuestConfigurationPolicyPackage
         [string]$storageAccountName,
         [Parameter(Mandatory = $false,
                    HelpMessage = '[string] Storage SKU Name')]
-        [string]$storageSKUName
+        [string]$storageSKUName = 'Standard_LRS'
     )
-
-    if ([System.String]::IsNullOrEmpty($storageSKUName))
-    {
-        $storageSKUName = "Standard_LRS"
-    }
-
-    if ([System.String]::IsNullOrEmpty($ResourceGroupLocation))
-    {
-        $storageSKUName = "eastus"
-    }
 
     Write-Host "Connecting to Azure..." -NoNewLine
     Connect-AzAccount | Out-Null


### PR DESCRIPTION
It helps with troubleshooting the code, if each time I can enter a single line command such as:
```
New-EPDSCAzureGuestConfigurationPolicyPackage -ResourceGroupLocation <region> -ResourceGroupName <rgName> -storageContainerName <containerName> -storageAccountName <storageAccountName> -storageSKUName standard_lrs
```
Instead of answering questions step by step via Read-Host