### PR TITLE
Fixed broken brute force NSG rule

### DIFF
--- a/Workflow automation/BlockBruteforceAttack/azuredeploy.json
+++ b/Workflow automation/BlockBruteforceAttack/azuredeploy.json
@@ -112,7 +112,7 @@
                                 "body": {
                                     "properties": {
                                         "access": "Deny",
-                                        "destinationAddressPrefix": "Any",
+                                        "destinationAddressPrefix": "*",
                                         "destinationPortRange": "*",
                                         "direction": "Inbound",
                                         "priority": 100,


### PR DESCRIPTION
The current ARM template uses "ANY" as the source destination address prefix, but this is invalid. It should be *