### PR TITLE
Make New-ASCVASolution script compatible with Azure PowerShell module 5.x

### DIFF
--- a/Powershell scripts/Vulnerability Solution/New-ASCVASolution.ps1
+++ b/Powershell scripts/Vulnerability Solution/New-ASCVASolution.ps1
@@ -40,7 +40,6 @@
   When On every new VM to the subscription will be automatically attempted to link to the solution.
   Default: False  
   
-  
 .EXAMPLE
 .\New-ASCVASolution.ps1 -subscriptionId <Subscription ID> -resourceGroupName <RG Name> -vaSolutionName <New solution name> -vaType <Qualys/Rapid7> -autoUpdate <true/false> -licenseCode <License acquired by the vendor> -publicKey <Key provided by the vendor>
 
@@ -49,7 +48,7 @@
 
 .NOTES
    AUTHOR: Eli Sagie - ASC EEE 
-   LASTEDIT: April 28, 2020 1.01
+   LASTEDIT: January 22, 2021 2.00
     - Special thanks to Arik Riklin!
 
 .LINK

--- a/Powershell scripts/Vulnerability Solution/New-ASCVASolution.ps1
+++ b/Powershell scripts/Vulnerability Solution/New-ASCVASolution.ps1
@@ -86,22 +86,7 @@ param (
 	[string]$publicKey
 	)
 
-# Connect and set Azure subscription authentication token
-# In case you have logged in to different tenant/subscription: Exception calling "AcquireAccessToken" with "1" argument(s): "multiple_matching_tokens_detected: The cache contains multiple tokens satisfying the requirements.
-# Remove previous token cache:
-# $azProfile = [Microsoft.Azure.Commands.Common.Authentication.Abstractions.AzureRmProfileProvider]::Instance.ResetDefaultProfile()
-
-function Get-AzCachedAccessToken()
-{
-	$azProfile = [Microsoft.Azure.Commands.Common.Authentication.Abstractions.AzureRmProfileProvider]::Instance.Profile
-	$currentAzureContext = Get-AzContext
-	$profileClient = New-Object Microsoft.Azure.Commands.ResourceManager.Common.RMProfileClient($azProfile)
-	Write-Debug ("Getting access token for tenant" + $currentAzureContext.Subscription.TenantId)
-	$token = $profileClient.AcquireAccessToken($currentAzureContext.Subscription.TenantId)
-	$token.AccessToken
-	$accessToken = "Bearer " + $($token.AccessToken)
-}
-	$token = Get-AzCachedAccessToken
+$token = (Get-AzAccessToken).token
 
 #Variable declaration
 	$requestHeader = @{

--- a/Powershell scripts/Vulnerability Solution/New-ASCVASolution.ps1
+++ b/Powershell scripts/Vulnerability Solution/New-ASCVASolution.ps1
@@ -53,7 +53,7 @@
 
 .LINK
     This script posted to and discussed at the following locations:
-    https://github.com/JimGBritt/Azure-Security-Center
+    https://github.com/Azure/Azure-Security-Center/tree/master/Powershell%20scripts
 #>
 
 # Prerequisites

--- a/Powershell scripts/Vulnerability Solution/New-ASCVASolution.ps1
+++ b/Powershell scripts/Vulnerability Solution/New-ASCVASolution.ps1
@@ -1,3 +1,4 @@
+#Requires -Modules @{ ModuleName="Az.Accounts"; ModuleVersion="2.2.0" }
 <#  
 .SYNOPSIS  
   This script will create new Qualys or Rapid7 vulnerability assessment (VA) solution in Azure Security Center (ASC).


### PR DESCRIPTION
The `New-ASCVASolution.ps1` is incompatible with the Azure PowerShell `Az` module version 5 and higher (or module Az.Accounts version 2.2.0 and higher). 

A breaking change was introduced in the Az module v5.0.0 that doesn't allow the access token to be retrieved using the `Get-AzCachedAccessToken()` function. The Az module now has a built-in cmdlet for retrieving the access token: `Get-AzAccessToken`. 

This PR adds the following:
- Replace the `Get-AzCachedAccessToken` function with the built-in cmdlet `Get-AzAccessToken`.
- A module requirement is added to the top of the script. This requires module Az.Accounts version 2.2.0 or higher.
- Updated version info
- Fixed a broken url.

In the Notes section I updated to version 2.0.0. My update is a breaking change, therefore I found it appropriate to bump to the next major version number. 