### PR TITLE
Update labdeploy.json

### DIFF
--- a/Labs/Files/labdeploy.json
+++ b/Labs/Files/labdeploy.json
@@ -74,7 +74,7 @@
         "sqlServerName": "[toLower(concat('asclab-sql-',uniqueString(subscription().subscriptionId)))]",
         "sqlDatabaseName": "asclab-db",
         "aksClusterName": "asclab-aks",
-        "aksVersion": "1.16.13",
+        "aksVersion": "1.16.15",
         "aksDNSPrefix": "asclab-aks",
         "aksNetworkPlugin": "kubenet"
     },


### PR DESCRIPTION
I wasn't able to find any region that supported AKS 16.13.

East US appears to support 16.15 

KubernetesVersion    Upgrades
-------------------  -------------------------
1.19.6               None available
1.19.3               1.19.6
1.18.14              1.19.3, 1.19.6
1.18.10              1.18.14, 1.19.3, 1.19.6
1.17.16              1.18.10, 1.18.14
1.17.13              1.17.16, 1.18.10, 1.18.14
1.16.15              1.17.13, 1.17.16
1.16.13              1.16.15, 1.17.13, 1.17.16