### PR TITLE
Update to use 3.1.3 GuestConfiguration module to support non-marketplace Windows VM, also allow to policy to be deployed to Management Group level

### DIFF
--- a/Remediation scripts/Customize Endpoint Protection Recommendation/Modules/EndPointProtectionDSC/AzureGuestConfigurationPolicy/AzureGuestPolicyHelper.psm1
+++ b/Remediation scripts/Customize Endpoint Protection Recommendation/Modules/EndPointProtectionDSC/AzureGuestConfigurationPolicy/AzureGuestPolicyHelper.psm1
@@ -23,7 +23,7 @@ function New-EPDSCAzureGuestConfigurationPolicyPackage {
     )
 
     Write-Host "Connecting to Azure..." -NoNewLine
-    # Connect-AzAccount | Out-Null
+    Connect-AzAccount | Out-Null
 
     # Select Management Group for policy scope
     $managementGroupId = $null

--- a/Remediation scripts/Customize Endpoint Protection Recommendation/Modules/EndPointProtectionDSC/AzureGuestConfigurationPolicy/AzureGuestPolicyHelper.psm1
+++ b/Remediation scripts/Customize Endpoint Protection Recommendation/Modules/EndPointProtectionDSC/AzureGuestConfigurationPolicy/AzureGuestPolicyHelper.psm1
@@ -21,21 +21,9 @@ function New-EPDSCAzureGuestConfigurationPolicyPackage
 
     Write-Host "Connecting to Azure..." -NoNewLine
     Connect-AzAccount | Out-Null
-    $subscriptions = Get-AzSubscription | Where-Object {$_.State -eq "Enabled"}
 
-    # If there are more than one subscriptions, select which one to deploy to
-    if ($subscriptions.count -gt 1) {
-        $numberedSubscriptions = @()
-        For ($i=0; $i -lt $subscriptions.count; $i++) {
-            $numberedSubscriptions += $subscriptions[$i] | Select-Object @{Name = 'No'; Expression = {$i+1}},Name,Id, TenantId
-        }
-        
-        Write-Host "Select from following subscriptions"
-        $numberedSubscriptions | Format-Table
-
-        $subNumber = Read-Host "Select No"
-        Set-AzContext $numberedSubscriptions[$subNumber-1].Name | Out-Null
-    }
+    # Select a subscription to create Resource Group and Storage Account
+    Select-Subscription
     
     Write-Host "Done" -ForegroundColor Green
 
@@ -158,4 +146,22 @@ function Publish-EPDSCPackage
     } until ($response -and ($response.StatusCode -eq 200))
 
     return $url
+}
+
+function Select-Subscription {
+    $subscriptions = Get-AzSubscription | Where-Object {$_.State -eq "Enabled"}
+
+    # If there are more than one subscriptions, select which one to deploy to
+    if ($subscriptions.count -gt 1) {
+        $numberedSubscriptions = @()
+        For ($i=0; $i -lt $subscriptions.count; $i++) {
+            $numberedSubscriptions += $subscriptions[$i] | Select-Object @{Name = 'No'; Expression = {$i+1}},Name,Id, TenantId
+        }
+        
+        Write-Host "Select from following subscriptions"
+        $numberedSubscriptions | Format-Table
+
+        $subNumber = Read-Host "Select No"
+        Set-AzContext $numberedSubscriptions[$subNumber-1].Name | Out-Null
+    }
 }

--- a/Remediation scripts/Customize Endpoint Protection Recommendation/Modules/EndPointProtectionDSC/AzureGuestConfigurationPolicy/AzureGuestPolicyHelper.psm1
+++ b/Remediation scripts/Customize Endpoint Protection Recommendation/Modules/EndPointProtectionDSC/AzureGuestConfigurationPolicy/AzureGuestPolicyHelper.psm1
@@ -49,7 +49,7 @@ function New-EPDSCAzureGuestConfigurationPolicyPackage
 
     Write-Host "Generating Guest Configuration Package..." -NoNewLine
     $package = New-GuestConfigurationPackage -Name MonitorAntivirus `
-        -Configuration "$env:Temp/MonitorAntivirus/MonitorAntivirus.mof"
+        -Configuration "$env:Temp/MonitorAntivirus/MonitorAntivirus.mof" -Force
     Write-Host "Done" -ForegroundColor Green
 
     Write-Host "Publishing Package to Azure Storage..." -NoNewLine

--- a/Remediation scripts/Customize Endpoint Protection Recommendation/Modules/EndPointProtectionDSC/EndPointProtectionDSC.psd1
+++ b/Remediation scripts/Customize Endpoint Protection Recommendation/Modules/EndPointProtectionDSC/EndPointProtectionDSC.psd1
@@ -48,7 +48,7 @@
   RequiredModules   = @(
         @{
             ModuleName      = "GuestConfiguration"
-            RequiredVersion = "1.19.4"
+            RequiredVersion = "3.1.3"
         }
   )
 


### PR DESCRIPTION
1. GuestConfiguration module 1.19.4 seems to be inconsistently generating either one or three policy .json files.

  When three policy json files were generated, it only supports marketplace images.
  When a single policy json file was generated, it supports both marketplace images and non-marketplace Windows VMs.
  
  Custom Endpoint Protection should work on Windows Azure VMs, regardless if they are from marketplace image or not.
  
  I have tested a few times with GuestConfiguration module 3.1.3, which seems to consistently output a single policy json file, which supports both marketplace and non-marketplace Azure Windows VMs.

2. I have moved select subscription code to it's own function for better readability.

3. I have added function to select Management Group, for the policy to be deployed to. By default, the policy will be deployed to same subscription as the resource group with the storage account. When you use -policyScope managementGroup, you will be promoted and select a management group as the deployment scope.
