### PR TITLE
Updated labdeploy.json aksVersion to 1.19.11

### DIFF
--- a/Labs/Files/labdeploy.json
+++ b/Labs/Files/labdeploy.json
@@ -74,7 +74,7 @@
         "sqlServerName": "[toLower(concat('asclab-sql-',uniqueString(subscription().subscriptionId)))]",
         "sqlDatabaseName": "asclab-db",
         "aksClusterName": "asclab-aks",
-        "aksVersion": "1.19.7",
+        "aksVersion": "1.19.11",
         "aksDNSPrefix": "asclab-aks",
         "aksNetworkPlugin": "kubenet"
     },


### PR DESCRIPTION
ARM template deployment was failing - previous AKS version 1.19.7 is not supported in the Canada Central region. Minimum supported is 1.19.11.