### PR TITLE
Enable guest configuration package versioning and include situation when server is a Domain Controller

### DIFF
--- a/Remediation scripts/Customize Endpoint Protection Recommendation/Modules/EndPointProtectionDSC/DSCResources/MSFT_EPAntivirusStatus/MSFT_EPAntivirusStatus.psm1
+++ b/Remediation scripts/Customize Endpoint Protection Recommendation/Modules/EndPointProtectionDSC/DSCResources/MSFT_EPAntivirusStatus/MSFT_EPAntivirusStatus.psm1
@@ -161,7 +161,7 @@ function Get-TargetResource
             return $nullReturn
         }
     }
-    elseif ($OSInfo.ProductType -eq 3)
+    elseif (($OSInfo.ProductType -eq 2) -or ($OSInfo.ProductType -eq 3)) # ProductType=3 Windows Server, ProductType=2 Domain Controller, which is also Windows Server
     {
         Write-Verbose -Message "Windows Server OS Detected"
 


### PR DESCRIPTION
1. According to https://docs.microsoft.com/en-us/azure/governance/policy/how-to/guest-configuration-create-definition#policy-lifecycle, it's recommended to include a version number in the package name, as well as update Version and contentUri when using New-GuestConfigurationPolicy. The original code hardcoded to use version 1.0.0, so consquent package updates were ignored. I have included versioning in the new code.
2. Previous code using (Get-CimInstance -ClassName Win32_OperatingSystem).ProductType to deteremine if OS is Desktop or Server, but the condition only includes 1 (Desktop) or 3 (Server), it was missing 2 (Domain Controller), which is really also a server product. This cause the script to fail on a domain controller.

Both issues were logged in ticket: 2104130010004629