### PR TITLE
feat(policy): add custom Defender CSPM policy for all extensions

### DIFF
--- a/Policy/Configure Microsoft Defender CSPM plan/Policy/custom-policy-cspm.tf
+++ b/Policy/Configure Microsoft Defender CSPM plan/Policy/custom-policy-cspm.tf
@@ -1,0 +1,352 @@
+resource "azurerm_policy_definition" "custom_defender_cspm" {
+  name                = "custom-defender-cspm-policy"
+  policy_type         = "Custom"
+  mode                = "All"
+  display_name        = "CUSTOM - Configure Microsoft Defender CSPM plan"
+  management_group_id = var.management_group_id
+
+  description = "Microsoft Defender for Cloud Posture Management (CSPM) continuously discovers and scores your cloud environment. This custom policy enables all CSPM capabilities with configurable extensions including those not available in the built-in policy (ApiPosture, AgentlessServerlessPosture, ServerlessContainers, DatabricksSecurityPosture)."
+
+  metadata = jsonencode({
+    version  = "1.0.0"
+    category = "Security Center"
+  })
+
+  policy_rule = jsonencode({
+    if = {
+      field  = "type"
+      equals = "Microsoft.Resources/subscriptions"
+    }
+    then = {
+      effect = "[parameters('effect')]"
+      details = {
+        type              = "Microsoft.Security/pricings"
+        name              = "CloudPosture"
+        deploymentScope   = "subscription"
+        existenceScope    = "subscription"
+        roleDefinitionIds = ["/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"]
+        existenceCondition = {
+          allOf = [
+            {
+              field  = "Microsoft.Security/pricings/pricingTier"
+              equals = "Standard"
+            },
+            {
+              count = {
+                field = "Microsoft.Security/pricings/extensions[*]"
+                where = {
+                  allOf = [
+                    {
+                      field  = "Microsoft.Security/pricings/extensions[*].name"
+                      equals = "SensitiveDataDiscovery"
+                    },
+                    {
+                      field  = "Microsoft.Security/pricings/extensions[*].isEnabled"
+                      equals = "[parameters('isSensitiveDataDiscoveryEnabled')]"
+                    }
+                  ]
+                }
+              }
+              equals = 1
+            },
+            {
+              count = {
+                field = "Microsoft.Security/pricings/extensions[*]"
+                where = {
+                  allOf = [
+                    {
+                      field  = "Microsoft.Security/pricings/extensions[*].name"
+                      equals = "ContainerRegistriesVulnerabilityAssessments"
+                    },
+                    {
+                      field  = "Microsoft.Security/pricings/extensions[*].isEnabled"
+                      equals = "[parameters('isContainerRegistriesVulnerabilityAssessmentsEnabled')]"
+                    }
+                  ]
+                }
+              }
+              equals = 1
+            },
+            {
+              count = {
+                field = "Microsoft.Security/pricings/extensions[*]"
+                where = {
+                  allOf = [
+                    {
+                      field  = "Microsoft.Security/pricings/extensions[*].name"
+                      equals = "AgentlessDiscoveryForKubernetes"
+                    },
+                    {
+                      field  = "Microsoft.Security/pricings/extensions[*].isEnabled"
+                      equals = "[parameters('isAgentlessDiscoveryForKubernetesEnabled')]"
+                    }
+                  ]
+                }
+              }
+              equals = 1
+            },
+            {
+              count = {
+                field = "Microsoft.Security/pricings/extensions[*]"
+                where = {
+                  allOf = [
+                    {
+                      field  = "Microsoft.Security/pricings/extensions[*].name"
+                      equals = "AgentlessServerlessPosture"
+                    },
+                    {
+                      field  = "Microsoft.Security/pricings/extensions[*].isEnabled"
+                      equals = "[parameters('isAgentlessServerlessPostureEnabled')]"
+                    }
+                  ]
+                }
+              }
+              equals = 1
+            }
+          ]
+        }
+        deployment = {
+          location = "westeurope"
+          properties = {
+            mode = "incremental"
+            parameters = {
+              isSensitiveDataDiscoveryEnabled = {
+                value = "[parameters('isSensitiveDataDiscoveryEnabled')]"
+              }
+              isContainerRegistriesVulnerabilityAssessmentsEnabled = {
+                value = "[parameters('isContainerRegistriesVulnerabilityAssessmentsEnabled')]"
+              }
+              isAgentlessDiscoveryForKubernetesEnabled = {
+                value = "[parameters('isAgentlessDiscoveryForKubernetesEnabled')]"
+              }
+              isAgentlessVmScanningEnabled = {
+                value = "[parameters('isAgentlessVmScanningEnabled')]"
+              }
+              isEntraPermissionsManagementEnabled = {
+                value = "[parameters('isEntraPermissionsManagementEnabled')]"
+              }
+              isApiPostureEnabled = {
+                value = "[parameters('isApiPostureEnabled')]"
+              }
+              isAgentlessServerlessPostureEnabled = {
+                value = "[parameters('isAgentlessServerlessPostureEnabled')]"
+              }
+              isServerlessContainersEnabled = {
+                value = "[parameters('isServerlessContainersEnabled')]"
+              }
+              isDatabricksSecurityPostureEnabled = {
+                value = "[parameters('isDatabricksSecurityPostureEnabled')]"
+              }
+            }
+            template = {
+              "$schema"      = "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#"
+              contentVersion = "1.0.0.0"
+              parameters = {
+                isSensitiveDataDiscoveryEnabled = {
+                  type = "String"
+                }
+                isContainerRegistriesVulnerabilityAssessmentsEnabled = {
+                  type = "String"
+                }
+                isAgentlessDiscoveryForKubernetesEnabled = {
+                  type = "String"
+                }
+                isAgentlessVmScanningEnabled = {
+                  type = "String"
+                }
+                isEntraPermissionsManagementEnabled = {
+                  type = "String"
+                }
+                isApiPostureEnabled = {
+                  type = "String"
+                }
+                isAgentlessServerlessPostureEnabled = {
+                  type = "String"
+                }
+                isServerlessContainersEnabled = {
+                  type = "String"
+                }
+                isDatabricksSecurityPostureEnabled = {
+                  type = "String"
+                }
+              }
+              resources = [
+                {
+                  type       = "Microsoft.Security/pricings"
+                  apiVersion = "2023-01-01"
+                  name       = "CloudPosture"
+                  properties = {
+                    pricingTier = "Standard"
+                    extensions = [
+                      {
+                        name      = "SensitiveDataDiscovery"
+                        isEnabled = "[parameters('isSensitiveDataDiscoveryEnabled')]"
+                      },
+                      {
+                        name      = "ContainerRegistriesVulnerabilityAssessments"
+                        isEnabled = "[parameters('isContainerRegistriesVulnerabilityAssessmentsEnabled')]"
+                      },
+                      {
+                        name      = "AgentlessDiscoveryForKubernetes"
+                        isEnabled = "[parameters('isAgentlessDiscoveryForKubernetesEnabled')]"
+                      },
+                      {
+                        name      = "AgentlessVmScanning"
+                        isEnabled = "[parameters('isAgentlessVmScanningEnabled')]"
+                      },
+                      {
+                        name      = "EntraPermissionsManagement"
+                        isEnabled = "[parameters('isEntraPermissionsManagementEnabled')]"
+                      },
+                      {
+                        name      = "ApiPosture"
+                        isEnabled = "[parameters('isApiPostureEnabled')]"
+                      },
+                      {
+                        name      = "AgentlessServerlessPosture"
+                        isEnabled = "[parameters('isAgentlessServerlessPostureEnabled')]"
+                      },
+                      {
+                        name      = "ServerlessContainers"
+                        isEnabled = "[parameters('isServerlessContainersEnabled')]"
+                      },
+                      {
+                        name      = "DatabricksSecurityPosture"
+                        isEnabled = "[parameters('isDatabricksSecurityPostureEnabled')]"
+                      }
+                    ]
+                  }
+                }
+              ]
+              outputs = {}
+            }
+          }
+        }
+      }
+    }
+  })
+
+  parameters = jsonencode({
+    effect = {
+      type = "String"
+      metadata = {
+        displayName = "Effect"
+        description = "The effect determines what happens when the policy rule is evaluated to match"
+      }
+      allowedValues = [
+        "DeployIfNotExists",
+        "AuditIfNotExists",
+        "Disabled"
+      ]
+      defaultValue = "DeployIfNotExists"
+    }
+    isSensitiveDataDiscoveryEnabled = {
+      type = "String"
+      metadata = {
+        displayName = "Sensitive Data Discovery Enabled"
+        description = "Enable sensitive data discovery (True/False)"
+      }
+      allowedValues = [
+        "True",
+        "False"
+      ]
+      defaultValue = "True"
+    }
+    isContainerRegistriesVulnerabilityAssessmentsEnabled = {
+      type = "String"
+      metadata = {
+        displayName = "Container Registries Vulnerability Assessments Enabled"
+        description = "Enable vulnerability assessments for container registries (True/False)"
+      }
+      allowedValues = [
+        "True",
+        "False"
+      ]
+      defaultValue = "True"
+    }
+    isAgentlessDiscoveryForKubernetesEnabled = {
+      type = "String"
+      metadata = {
+        displayName = "Agentless Discovery For Kubernetes Enabled"
+        description = "Enable agentless discovery for Kubernetes (True/False)"
+      }
+      allowedValues = [
+        "True",
+        "False"
+      ]
+      defaultValue = "True"
+    }
+    isAgentlessVmScanningEnabled = {
+      type = "String"
+      metadata = {
+        displayName = "Agentless VM Scanning Enabled"
+        description = "Enable agentless VM scanning (True/False)"
+      }
+      allowedValues = [
+        "True",
+        "False"
+      ]
+      defaultValue = "True"
+    }
+    isEntraPermissionsManagementEnabled = {
+      type = "String"
+      metadata = {
+        displayName = "Entra Permissions Management Enabled"
+        description = "Enable Entra Permissions Management (True/False)"
+      }
+      allowedValues = [
+        "True",
+        "False"
+      ]
+      defaultValue = "True"
+    }
+    isApiPostureEnabled = {
+      type = "String"
+      metadata = {
+        displayName = "API Posture Enabled"
+        description = "Enable API posture management (True/False) - NOT in built-in policy"
+      }
+      allowedValues = [
+        "True",
+        "False"
+      ]
+      defaultValue = "True"
+    }
+    isAgentlessServerlessPostureEnabled = {
+      type = "String"
+      metadata = {
+        displayName = "Agentless Serverless Posture Enabled"
+        description = "Enable agentless serverless posture management (True/False) - NOT in built-in policy"
+      }
+      allowedValues = [
+        "True",
+        "False"
+      ]
+      defaultValue = "True"
+    }
+    isServerlessContainersEnabled = {
+      type = "String"
+      metadata = {
+        displayName = "Serverless Containers Enabled"
+        description = "Enable serverless containers scanning (True/False) - NOT in built-in policy"
+      }
+      allowedValues = [
+        "True",
+        "False"
+      ]
+      defaultValue = "True"
+    }
+    isDatabricksSecurityPostureEnabled = {
+      type = "String"
+      metadata = {
+        displayName = "Databricks Security Posture Enabled"
+        description = "Enable Databricks security posture management (True/False) - NOT in built-in policy"
+      }
+      allowedValues = [
+        "True",
+        "False"
+      ]
+      defaultValue = "False"
+    }
+  })
+}

--- a/Policy/Configure Microsoft Defender CSPM plan/README.md
+++ b/Policy/Configure Microsoft Defender CSPM plan/README.md
@@ -1,0 +1,196 @@
+# Configure Microsoft Defender CSPM Plan (All Extensions)
+
+## Overview
+
+This custom policy enables **Microsoft Defender for Cloud Security Posture Management (CSPM)** at subscription scope and exposes all 9 available CSPM extensions as independently configurable parameters.
+
+It extends the built-in policy [Configure Microsoft Defender CSPM plan](https://portal.azure.com/#blade/Microsoft_Azure_Policy/PolicyDetailBlade/definitionId/%2Fproviders%2FMicrosoft.Authorization%2FpolicyDefinitions%2F72f8cee7-2937-403d-84a1-a4e3e57f3c21) (`72f8cee7-2937-403d-84a1-a4e3e57f3c21`) by adding 4 extensions that are available in the ARM API but not configurable through the built-in policy.
+
+---
+
+## Why This Policy Exists
+
+The built-in CSPM policy only exposes 5 of the 9 available extensions on `Microsoft.Security/pricings/CloudPosture`. The following extensions cannot be managed at scale through the built-in policy:
+
+| Extension | Available in ARM API | Configurable via built-in policy |
+|-----------|---------------------|----------------------------------|
+| SensitiveDataDiscovery | ✅ | ✅ |
+| ContainerRegistriesVulnerabilityAssessments | ✅ | ✅ |
+| AgentlessDiscoveryForKubernetes | ✅ | ✅ |
+| AgentlessVmScanning | ✅ | ✅ |
+| EntraPermissionsManagement | ✅ | ✅ |
+| ApiPosture | ✅ | ❌ |
+| AgentlessServerlessPosture | ✅ | ❌ |
+| ServerlessContainers | ✅ | ❌ |
+| DatabricksSecurityPosture | ✅ | ❌ |
+
+This policy fills that gap, enabling organizations to govern all CSPM extension states consistently across subscriptions via a single policy assignment at Management Group scope.
+
+---
+
+## Policy Details
+
+| Property | Value |
+|----------|-------|
+| **Display Name** | Configure Microsoft Defender CSPM plan (All Extensions) |
+| **Category** | Security Center |
+| **Mode** | All |
+| **Resource Type** | `Microsoft.Resources/subscriptions` |
+| **Deployment Target** | `Microsoft.Security/pricings/CloudPosture` |
+| **Deployment Scope** | Subscription |
+| **API Version** | `2024-01-01` |
+| **Required Role** | Contributor (`b24988ac-6180-42a0-ab88-20f7382dd24c`) |
+| **Supported Effects** | `DeployIfNotExists`, `AuditIfNotExists`, `Disabled` |
+
+---
+
+## Parameters
+
+| Parameter Name | Display Name | Allowed Values | Default | Notes |
+|----------------|-------------|----------------|---------|-------|
+| `effect` | Effect | `DeployIfNotExists`, `AuditIfNotExists`, `Disabled` | `DeployIfNotExists` | |
+| `isSensitiveDataDiscoveryEnabled` | Sensitive Data Discovery Enabled | `True`, `False` | `True` | Also in built-in policy |
+| `isContainerRegistriesVulnerabilityAssessmentsEnabled` | Container Registries Vulnerability Assessments Enabled | `True`, `False` | `True` | Also in built-in policy |
+| `isAgentlessDiscoveryForKubernetesEnabled` | Agentless Discovery For Kubernetes Enabled | `True`, `False` | `True` | Also in built-in policy |
+| `isAgentlessVmScanningEnabled` | Agentless VM Scanning Enabled | `True`, `False` | `True` | Also in built-in policy |
+| `isEntraPermissionsManagementEnabled` | Entra Permissions Management Enabled | `True`, `False` | `True` | Also in built-in policy |
+| `isApiPostureEnabled` | API Posture Enabled | `True`, `False` | `True` | **Not in built-in policy** |
+| `isAgentlessServerlessPostureEnabled` | Agentless Serverless Posture Enabled | `True`, `False` | `True` | **Not in built-in policy** |
+| `isServerlessContainersEnabled` | Serverless Containers Enabled | `True`, `False` | `True` | **Not in built-in policy** |
+| `isDatabricksSecurityPostureEnabled` | Databricks Security Posture Enabled | `True`, `False` | `False` | **Not in built-in policy** |
+
+---
+
+## How It Works
+
+### Compliance Evaluation
+
+The policy evaluates compliance by checking:
+
+1. `Microsoft.Security/pricings/CloudPosture` exists with `pricingTier = Standard`
+2. The following extensions match the configured parameter values (checked via `count` expressions):
+   - `SensitiveDataDiscovery`
+   - `ContainerRegistriesVulnerabilityAssessments`
+   - `AgentlessDiscoveryForKubernetes`
+   - `AgentlessServerlessPosture`
+
+> **Note:** Azure Policy enforces a limit of 5 `count` expressions per `existenceCondition`. This policy validates 4 extensions in the compliance check while deploying all 9 through the ARM template. Subscriptions will be re-evaluated and remediated if any of the 4 checked extensions drift from the desired state.
+
+### Remediation
+
+When a subscription is found non-compliant, the policy deploys an ARM template at subscription scope that sets all 9 extensions in a single `Microsoft.Security/pricings/CloudPosture` resource PUT operation.
+
+To remediate existing non-compliant subscriptions after assignment, create a remediation task:
+
+```bash
+az policy remediation create \
+  --name "remediate-cspm" \
+  --policy-assignment "<assignment-id>" \
+  --resource-discovery-mode ExistingNonCompliant
+```
+
+### Required RBAC
+
+The policy assignment's managed identity requires the **Contributor** role at the scope where it is assigned (e.g., Management Group) in order to deploy `Microsoft.Security/pricings` resources into child subscriptions.
+
+```bash
+az role assignment create \
+  --role "Contributor" \
+  --assignee "<assignment-principal-id>" \
+  --scope "/providers/Microsoft.Management/managementGroups/<mg-id>"
+```
+
+---
+
+## Usage Example
+
+### Azure CLI
+
+```bash
+# Assign the policy at Management Group scope
+az policy assignment create \
+  --name "cspm-all-extensions" \
+  --display-name "Configure Microsoft Defender CSPM plan (All Extensions)" \
+  --policy "<policy-definition-id>" \
+  --scope "/providers/Microsoft.Management/managementGroups/<mg-id>" \
+  --location "eastus" \
+  --mi-system-assigned \
+  --params '{
+    "effect": { "value": "DeployIfNotExists" },
+    "isSensitiveDataDiscoveryEnabled": { "value": "True" },
+    "isContainerRegistriesVulnerabilityAssessmentsEnabled": { "value": "True" },
+    "isAgentlessDiscoveryForKubernetesEnabled": { "value": "True" },
+    "isAgentlessVmScanningEnabled": { "value": "True" },
+    "isEntraPermissionsManagementEnabled": { "value": "True" },
+    "isApiPostureEnabled": { "value": "True" },
+    "isAgentlessServerlessPostureEnabled": { "value": "True" },
+    "isServerlessContainersEnabled": { "value": "True" },
+    "isDatabricksSecurityPostureEnabled": { "value": "True" }
+  }'
+```
+
+### Terraform
+
+```hcl
+resource "azurerm_management_group_policy_assignment" "cspm" {
+  name                 = "cspm-all-extensions"
+  display_name         = "Configure Microsoft Defender CSPM plan (All Extensions)"
+  management_group_id  = "/providers/Microsoft.Management/managementGroups/<mg-id>"
+  policy_definition_id = azurerm_policy_definition.cspm.id
+  location             = "eastus"
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  parameters = jsonencode({
+    effect                                               = { value = "DeployIfNotExists" }
+    isSensitiveDataDiscoveryEnabled                      = { value = "True" }
+    isContainerRegistriesVulnerabilityAssessmentsEnabled = { value = "True" }
+    isAgentlessDiscoveryForKubernetesEnabled             = { value = "True" }
+    isAgentlessVmScanningEnabled                         = { value = "True" }
+    isEntraPermissionsManagementEnabled                  = { value = "True" }
+    isApiPostureEnabled                                  = { value = "True" }
+    isAgentlessServerlessPostureEnabled                  = { value = "True" }
+    isServerlessContainersEnabled                        = { value = "True" }
+    isDatabricksSecurityPostureEnabled                   = { value = "False" }
+  })
+}
+```
+
+---
+
+## Verification
+
+After remediation completes, verify all extensions are configured correctly:
+
+```bash
+az rest --method get \
+  --url "https://management.azure.com/subscriptions/<subscription-id>/providers/Microsoft.Security/pricings/CloudPosture?api-version=2024-01-01" \
+  --query "properties.extensions[].{Name:name, Enabled:isEnabled}"
+```
+
+Expected output:
+
+```json
+[
+  { "Name": "SensitiveDataDiscovery",                       "Enabled": "True" },
+  { "Name": "ContainerRegistriesVulnerabilityAssessments",  "Enabled": "True" },
+  { "Name": "AgentlessDiscoveryForKubernetes",              "Enabled": "True" },
+  { "Name": "AgentlessVmScanning",                          "Enabled": "True" },
+  { "Name": "EntraPermissionsManagement",                   "Enabled": "True" },
+  { "Name": "ApiPosture",                                   "Enabled": "True" },
+  { "Name": "AgentlessServerlessPosture",                   "Enabled": "True" },
+  { "Name": "ServerlessContainers",                         "Enabled": "True" },
+  { "Name": "DatabricksSecurityPosture",                    "Enabled": "False" }
+]
+```
+
+---
+
+## Related Resources
+
+- [Built-in policy: Configure Microsoft Defender CSPM plan](https://portal.azure.com/#blade/Microsoft_Azure_Policy/PolicyDetailBlade/definitionId/%2Fproviders%2FMicrosoft.Authorization%2FpolicyDefinitions%2F72f8cee7-2937-403d-84a1-a4e3e57f3c21) (`72f8cee7-2937-403d-84a1-a4e3e57f3c21`)
+- [Microsoft.Security/pricings ARM reference](https://learn.microsoft.com/en-us/azure/templates/microsoft.security/pricings)
+- [Microsoft Defender for Cloud — CSPM overview](https://learn.microsoft.com/en-us/azure/defender-for-cloud/concept-cloud-security-posture-management)
+- [Azure Policy DeployIfNotExists effect](https://learn.microsoft.com/en-us/azure/governance/policy/concepts/effect-deploy-if-not-exists)


### PR DESCRIPTION
## Summary
 - Add custom policy to configure Defender CSPM with all 9 extensions
 - Include 4 extensions not exposed by built-in policy
 - Add README with assignment, remediation, and verification guidance

 Closes azure/Microsoft-Defender-for-Cloud#1039