### PR TITLE
feat(policy): add custom Defender for Storage policy with full extension controls

### DIFF
--- a/Policy/Configure Microsoft Defender for Storage to be enabled/Policy/custom-policy-storage.tf
+++ b/Policy/Configure Microsoft Defender for Storage to be enabled/Policy/custom-policy-storage.tf
@@ -1,0 +1,230 @@
+resource "azurerm_policy_definition" "custom_defender_storage" {
+  name                = "custom-defender-storage-policy"
+  policy_type         = "Custom"
+  mode                = "All"
+  display_name        = "CUSTOM - Configure Microsoft Defender for Storage to be enabled"
+  management_group_id = var.management_group_id
+
+  description = "Microsoft Defender for Storage is an Azure-native layer of security intelligence that detects potential threats to your storage accounts. This custom policy will enable all Defender for Storage capabilities with configurable extension properties. This version fixes case-sensitivity issues in the built-in policy."
+
+  metadata = jsonencode({
+    version  = "1.0.0"
+    category = "Security Center"
+  })
+
+  policy_rule = jsonencode({
+    if = {
+      field  = "type"
+      equals = "Microsoft.Resources/subscriptions"
+    }
+    then = {
+      effect = "[parameters('effect')]"
+      details = {
+        type              = "Microsoft.Security/pricings"
+        name              = "StorageAccounts"
+        deploymentScope   = "subscription"
+        existenceScope    = "subscription"
+        roleDefinitionIds = ["/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"]
+        existenceCondition = {
+          allOf = [
+            {
+              field  = "Microsoft.Security/pricings/pricingTier"
+              equals = "Standard"
+            },
+            {
+              field  = "Microsoft.Security/pricings/subPlan"
+              equals = "DefenderForStorageV2"
+            },
+            {
+              count = {
+                field = "Microsoft.Security/pricings/extensions[*]"
+                where = {
+                  allOf = [
+                    {
+                      field  = "Microsoft.Security/pricings/extensions[*].name"
+                      equals = "OnUploadMalwareScanning"
+                    },
+                    {
+                      field  = "Microsoft.Security/pricings/extensions[*].isEnabled"
+                      equals = "[parameters('isOnUploadMalwareScanningEnabled')]"
+                    }
+                  ]
+                }
+              }
+              equals = 1
+            },
+            {
+              count = {
+                field = "Microsoft.Security/pricings/extensions[*]"
+                where = {
+                  allOf = [
+                    {
+                      field  = "Microsoft.Security/pricings/extensions[*].name"
+                      equals = "SensitiveDataDiscovery"
+                    },
+                    {
+                      field  = "Microsoft.Security/pricings/extensions[*].isEnabled"
+                      equals = "[parameters('isSensitiveDataDiscoveryEnabled')]"
+                    }
+                  ]
+                }
+              }
+              equals = 1
+            }
+          ]
+        }
+        deployment = {
+          location = "westeurope"
+          properties = {
+            mode = "incremental"
+            parameters = {
+              isOnUploadMalwareScanningEnabled = {
+                value = "[parameters('isOnUploadMalwareScanningEnabled')]"
+              }
+              capGBPerMonthPerStorageAccount = {
+                value = "[parameters('capGBPerMonthPerStorageAccount')]"
+              }
+              automatedResponseOption = {
+                value = "[parameters('automatedResponseOption')]"
+              }
+              blobScanResultsOption = {
+                value = "[parameters('blobScanResultsOption')]"
+              }
+              isSensitiveDataDiscoveryEnabled = {
+                value = "[parameters('isSensitiveDataDiscoveryEnabled')]"
+              }
+            }
+            template = {
+              "$schema"      = "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#"
+              contentVersion = "1.0.0.0"
+              parameters = {
+                isOnUploadMalwareScanningEnabled = {
+                  type = "String"
+                }
+                capGBPerMonthPerStorageAccount = {
+                  type = "int"
+                }
+                automatedResponseOption = {
+                  type = "String"
+                }
+                blobScanResultsOption = {
+                  type = "String"
+                }
+                isSensitiveDataDiscoveryEnabled = {
+                  type = "String"
+                }
+              }
+              variables = {
+                enabledMalwareScanningExtension = {
+                  name      = "OnUploadMalwareScanning"
+                  isEnabled = "True"
+                  additionalExtensionProperties = {
+                    AutomatedResponse              = "[parameters('automatedResponseOption')]"
+                    BlobScanResultsOptions         = "[parameters('blobScanResultsOption')]"
+                    CapGBPerMonthPerStorageAccount = "[parameters('capGBPerMonthPerStorageAccount')]"
+                  }
+                }
+                disabledMalwareScanningExtension = {
+                  name      = "OnUploadMalwareScanning"
+                  isEnabled = "False"
+                }
+                malwareScanningExtension = "[if(equals(toLower(parameters('isOnUploadMalwareScanningEnabled')),'true'), variables('enabledMalwareScanningExtension'), variables('disabledMalwareScanningExtension'))]"
+              }
+              resources = [
+                {
+                  type       = "Microsoft.Security/pricings"
+                  apiVersion = "2023-01-01"
+                  name       = "StorageAccounts"
+                  properties = {
+                    pricingTier = "Standard"
+                    subPlan     = "DefenderForStorageV2"
+                    extensions = [
+                      "[variables('malwareScanningExtension')]",
+                      {
+                        name      = "SensitiveDataDiscovery"
+                        isEnabled = "[parameters('isSensitiveDataDiscoveryEnabled')]"
+                      }
+                    ]
+                  }
+                }
+              ]
+              outputs = {}
+            }
+          }
+        }
+      }
+    }
+  })
+
+  parameters = jsonencode({
+    effect = {
+      type = "String"
+      metadata = {
+        displayName = "Effect"
+        description = "The effect determines what happens when the policy rule is evaluated to match"
+      }
+      allowedValues = [
+        "DeployIfNotExists",
+        "AuditIfNotExists",
+        "Disabled"
+      ]
+      defaultValue = "DeployIfNotExists"
+    }
+    isOnUploadMalwareScanningEnabled = {
+      type = "String"
+      metadata = {
+        displayName = "On-Upload Malware Scanning Enabled"
+        description = "Enable malware scanning on blob uploads (True/False)"
+      }
+      allowedValues = [
+        "True",
+        "False"
+      ]
+      defaultValue = "True"
+    }
+    capGBPerMonthPerStorageAccount = {
+      type = "Integer"
+      metadata = {
+        displayName = "Cap GB Per Month Per Storage Account"
+        description = "Limit the GB scanned per month for each storage account. Minimum value is 10. Set to -1 for unlimited scanning"
+      }
+      defaultValue = 10
+    }
+    automatedResponseOption = {
+      type = "String"
+      metadata = {
+        displayName = "Automated Response Option"
+        description = "Automated response for malware scanning findings (None or BlobSoftDelete)"
+      }
+      allowedValues = [
+        "None",
+        "BlobSoftDelete"
+      ]
+      defaultValue = "BlobSoftDelete"
+    }
+    blobScanResultsOption = {
+      type = "String"
+      metadata = {
+        displayName = "Blob Scan Results Option"
+        description = "Where to store blob scan results"
+      }
+      allowedValues = [
+        "BlobIndexTags",
+        "None"
+      ]
+      defaultValue = "None"
+    }
+    isSensitiveDataDiscoveryEnabled = {
+      type = "String"
+      metadata = {
+        displayName = "Sensitive Data Discovery Enabled"
+        description = "Enable sensitive data discovery (True/False)"
+      }
+      allowedValues = [
+        "True",
+        "False"
+      ]
+      defaultValue = "True"
+    }
+  })
+}

--- a/Policy/Configure Microsoft Defender for Storage to be enabled/README.md
+++ b/Policy/Configure Microsoft Defender for Storage to be enabled/README.md
@@ -1,0 +1,160 @@
+# Configure Microsoft Defender for Storage to be enabled
+
+## Overview
+
+This custom policy enables **Microsoft Defender for Storage** at subscription scope and exposes the full set of configurable storage Defender settings available through the ARM API.
+
+It extends the built-in policy **Configure Microsoft Defender for Storage to be enabled** by adding the additional extension properties that are not exposed in the built-in version.
+
+---
+
+## Why This Policy Exists
+
+The built-in Storage policy does not expose all configurable Defender for Storage settings. In particular, it does not let you configure:
+
+- `AutomatedResponse`
+- `BlobScanResultsOptions`
+
+This custom policy makes those settings available through parameters so they can be controlled consistently across subscriptions via Azure Policy.
+
+---
+
+## Policy Details
+
+| Property | Value |
+|---|---|
+| **Display Name** | CUSTOM - Configure Microsoft Defender for Storage to be enabled |
+| **Category** | Security Center |
+| **Mode** | All |
+| **Resource Type** | `Microsoft.Resources/subscriptions` |
+| **Deployment Target** | `Microsoft.Security/pricings/StorageAccounts` |
+| **Deployment Scope** | Subscription |
+| **API Version** | `2024-01-01` |
+| **Required Role** | Contributor (`b24988ac-6180-42a0-ab88-20f7382dd24c`) |
+| **Supported Effects** | `DeployIfNotExists`, `AuditIfNotExists`, `Disabled` |
+
+---
+
+## Parameters
+
+| Parameter Name | Display Name | Allowed Values | Default | Notes |
+|---|---|---|---|---|
+| `effect` | Effect | `DeployIfNotExists`, `AuditIfNotExists`, `Disabled` | `DeployIfNotExists` | |
+| `isOnUploadMalwareScanningEnabled` | On-Upload Malware Scanning Enabled | `True`, `False` | `True` | Also in built-in policy |
+| `capGBPerMonthPerStorageAccount` | Cap GB Per Month Per Storage Account | integer | `10` | Minimum `10`, use `-1` for unlimited |
+| `automatedResponseOption` | Automated Response Option | `None`, `BlobSoftDelete` | `BlobSoftDelete` | **Not exposed by built-in policy** |
+| `blobScanResultsOption` | Blob Scan Results Option | `BlobIndexTags`, `None` | `None` | **Validated against ARM; `StorageAccount` is invalid** |
+| `isSensitiveDataDiscoveryEnabled` | Sensitive Data Discovery Enabled | `True`, `False` | `True` | Also in built-in policy |
+
+---
+
+## How It Works
+
+### Compliance Evaluation
+
+The policy evaluates compliance by checking:
+
+1. `Microsoft.Security/pricings/StorageAccounts` exists with `pricingTier = Standard`
+2. `subPlan = DefenderForStorageV2`
+3. The configured extension values match the desired state
+
+### Remediation
+
+When a subscription is found non-compliant, the policy deploys an ARM template at subscription scope that sets:
+
+- `pricingTier = Standard`
+- `subPlan = DefenderForStorageV2`
+- `OnUploadMalwareScanning`
+- `SensitiveDataDiscovery`
+
+The malware scanning extension includes the configurable additional properties:
+
+- `AutomatedResponse`
+- `BlobScanResultsOptions`
+- `CapGBPerMonthPerStorageAccount`
+
+### Required RBAC
+
+The policy assignment's managed identity requires the **Contributor** role at the target scope to deploy `Microsoft.Security/pricings` resources into child subscriptions.
+
+---
+
+## Usage Example
+
+### Azure CLI
+
+```bash
+az policy assignment create \
+  --name "storage-defender-custom" \
+  --display-name "CUSTOM - Configure Microsoft Defender for Storage to be enabled" \
+  --policy "<policy-definition-id>" \
+  --scope "/providers/Microsoft.Management/managementGroups/<mg-id>" \
+  --location "eastus" \
+  --mi-system-assigned \
+  --params '{
+    "effect": { "value": "DeployIfNotExists" },
+    "isOnUploadMalwareScanningEnabled": { "value": "True" },
+    "capGBPerMonthPerStorageAccount": { "value": 10 },
+    "automatedResponseOption": { "value": "BlobSoftDelete" },
+    "blobScanResultsOption": { "value": "None" },
+    "isSensitiveDataDiscoveryEnabled": { "value": "True" }
+  }'
+```
+
+### Terraform
+
+```hcl
+resource "azurerm_management_group_policy_assignment" "storage" {
+  name                 = "custom-def-storage"
+  display_name         = "CUSTOM - Configure Microsoft Defender for Storage to be enabled"
+  management_group_id  = "/providers/Microsoft.Management/managementGroups/<mg-id>"
+  policy_definition_id = azurerm_policy_definition.storage.id
+  location             = "eastus"
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  parameters = jsonencode({
+    effect                           = { value = "DeployIfNotExists" }
+    isOnUploadMalwareScanningEnabled = { value = "True" }
+    capGBPerMonthPerStorageAccount   = { value = 10 }
+    automatedResponseOption          = { value = "BlobSoftDelete" }
+    blobScanResultsOption            = { value = "None" }
+    isSensitiveDataDiscoveryEnabled  = { value = "True" }
+  })
+}
+```
+
+---
+
+## Verification
+
+After remediation completes, verify the pricing resource:
+
+```bash
+az rest --method get \
+  --url "https://management.azure.com/subscriptions/<subscription-id>/providers/Microsoft.Security/pricings/StorageAccounts?api-version=2024-01-01" \
+  --query "properties.extensions[?name=='OnUploadMalwareScanning'].additionalExtensionProperties"
+```
+
+Expected output:
+
+```json
+[
+  {
+    "AutomatedResponse": "BlobSoftDelete",
+    "BlobScanResultsOptions": "None",
+    "CapGBPerMonthPerStorageAccount": "10"
+  }
+]
+```
+
+---
+
+## Related Resources
+
+- Built-in policy: **Configure Microsoft Defender for Storage to be enabled**
+- ARM resource type: `Microsoft.Security/pricings`
+- Microsoft Defender for Cloud documentation
+- Azure Policy `DeployIfNotExists` effect


### PR DESCRIPTION
## Summary
 - Add custom Defender for Storage policy at subscription scope
 - Expose additional extension controls not available in built-in policy
 - Add README with usage, remediation, and verification guidance

 Closes azure/Microsoft-Defender-for-Cloud#1041