### PR TITLE
feat(policy): add custom Defender for APIs policy with configurable subPlan

### DIFF
--- a/Policy/Configure Microsoft Defender for APIs to be enabled/Policy/custom-policy-api.tf
+++ b/Policy/Configure Microsoft Defender for APIs to be enabled/Policy/custom-policy-api.tf
@@ -1,0 +1,105 @@
+resource "azurerm_policy_definition" "custom_defender_api" {
+  name                = "custom-defender-api-policy"
+  policy_type         = "Custom"
+  mode                = "All"
+  display_name        = "CUSTOM - Configure Microsoft Defender for APIs to be enabled"
+  management_group_id = var.management_group_id
+
+  description = "Microsoft Defender for APIs brings discovery, protection, detection, and response coverage to monitor common API-based attacks and security misconfigurations."
+
+  metadata = jsonencode({
+    version  = "1.0.0"
+    category = "Security Center"
+  })
+
+  policy_rule = jsonencode({
+    if = {
+      field  = "type"
+      equals = "Microsoft.Resources/subscriptions"
+    }
+    then = {
+      effect = "[parameters('effect')]"
+      details = {
+        type              = "Microsoft.Security/pricings"
+        name              = "Api"
+        deploymentScope   = "subscription"
+        existenceScope    = "subscription"
+        roleDefinitionIds = ["/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"]
+        existenceCondition = {
+          allOf = [
+            {
+              field  = "Microsoft.Security/pricings/pricingTier"
+              equals = "Standard"
+            },
+            {
+              field  = "Microsoft.Security/pricings/subPlan"
+              equals = "[parameters('subPlan')]"
+            }
+          ]
+        }
+        deployment = {
+          location = "westeurope"
+          properties = {
+            mode = "incremental"
+            template = {
+              "$schema"      = "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#"
+              contentVersion = "1.0.0.0"
+              parameters = {
+                subPlan = {
+                  type = "string"
+                }
+              }
+              resources = [
+                {
+                  type       = "Microsoft.Security/pricings"
+                  apiVersion = "2024-01-01"
+                  name       = "Api"
+                  properties = {
+                    pricingTier = "Standard"
+                    subPlan     = "[parameters('subPlan')]"
+                  }
+                }
+              ]
+              outputs = {}
+            }
+            parameters = {
+              subPlan = {
+                value = "[parameters('subPlan')]"
+              }
+            }
+          }
+        }
+      }
+    }
+  })
+
+  parameters = jsonencode({
+    effect = {
+      type = "String"
+      metadata = {
+        displayName = "Effect"
+        description = "Enable or disable the execution of the policy"
+      }
+      allowedValues = [
+        "DeployIfNotExists",
+        "Disabled"
+      ]
+      defaultValue = "DeployIfNotExists"
+    }
+    subPlan = {
+      type = "String"
+      metadata = {
+        displayName = "API pricing plan"
+        description = "Pricing plan for Defender for APIs."
+      }
+      allowedValues = [
+        "P1",
+        "P2",
+        "P3",
+        "P4",
+        "P5"
+      ]
+      defaultValue = "P1"
+    }
+  })
+}

--- a/Policy/Configure Microsoft Defender for APIs to be enabled/README.md
+++ b/Policy/Configure Microsoft Defender for APIs to be enabled/README.md
@@ -1,0 +1,139 @@
+# Configure Microsoft Defender for APIs to be enabled
+
+## Overview
+
+This custom policy enables **Microsoft Defender for APIs** at subscription scope and exposes the pricing plan required by the ARM API.
+
+It extends the built-in policy **Microsoft Defender for APIs should be enabled** by adding `subPlan` support so the API pricing resource can be configured at scale.
+
+---
+
+## Why This Policy Exists
+
+Defender for APIs requires more than just enabling the built-in policy. The live `Microsoft.Security/pricings/Api` resource must be created with:
+
+- `pricingTier = Standard`
+- `subPlan = P1` (or `P2`/`P3`/`P4`/`P5`)
+
+The built-in policy does not expose the pricing plan, so this custom policy makes it configurable.
+
+---
+
+## Policy Details
+
+| Property | Value |
+|---|---|
+| **Display Name** | CUSTOM - Configure Microsoft Defender for APIs to be enabled |
+| **Category** | Security Center |
+| **Mode** | All |
+| **Resource Type** | `Microsoft.Resources/subscriptions` |
+| **Deployment Target** | `Microsoft.Security/pricings/Api` |
+| **Deployment Scope** | Subscription |
+| **API Version** | `2024-01-01` |
+| **Required Role** | Contributor (`b24988ac-6180-42a0-ab88-20f7382dd24c`) |
+| **Supported Effects** | `DeployIfNotExists`, `Disabled` |
+
+---
+
+## Parameters
+
+| Parameter Name | Display Name | Allowed Values | Default | Notes |
+|---|---|---|---|---|
+| `effect` | Effect | `DeployIfNotExists`, `Disabled` | `DeployIfNotExists` | |
+| `subPlan` | API pricing plan | `P1`, `P2`, `P3`, `P4`, `P5` | `P1` | Required to enable Defender for APIs |
+
+---
+
+## How It Works
+
+### Compliance Evaluation
+
+The policy evaluates compliance by checking:
+
+1. `Microsoft.Security/pricings/Api` exists
+2. `pricingTier = Standard`
+3. `subPlan` matches the configured parameter
+
+### Remediation
+
+When a subscription is found non-compliant, the policy deploys an ARM template at subscription scope that sets:
+
+- `pricingTier = Standard`
+- `subPlan = <selected plan>`
+
+### Required RBAC
+
+The policy assignment's managed identity requires the **Contributor** role at the target scope to deploy `Microsoft.Security/pricings` resources into child subscriptions.
+
+---
+
+## Usage Example
+
+### Azure CLI
+
+```bash
+az policy assignment create \
+  --name "api-defender-custom" \
+  --display-name "CUSTOM - Configure Microsoft Defender for APIs to be enabled" \
+  --policy "<policy-definition-id>" \
+  --scope "/providers/Microsoft.Management/managementGroups/<mg-id>" \
+  --location "eastus" \
+  --mi-system-assigned \
+  --params '{
+    "effect": { "value": "DeployIfNotExists" },
+    "subPlan": { "value": "P1" }
+  }'
+```
+
+### Terraform
+
+```hcl
+resource "azurerm_management_group_policy_assignment" "api" {
+  name                 = "custom-def-api"
+  display_name         = "CUSTOM - Configure Microsoft Defender for APIs to be enabled"
+  management_group_id  = "/providers/Microsoft.Management/managementGroups/<mg-id>"
+  policy_definition_id = azurerm_policy_definition.api.id
+  location             = "eastus"
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  parameters = jsonencode({
+    effect  = { value = "DeployIfNotExists" }
+    subPlan = { value = "P1" }
+  })
+}
+```
+
+---
+
+## Verification
+
+After remediation completes, verify the pricing resource:
+
+```bash
+az rest --method get \
+  --url "https://management.azure.com/subscriptions/<subscription-id>/providers/Microsoft.Security/pricings/Api?api-version=2024-01-01"
+```
+
+Expected output:
+
+```json
+{
+  "name": "Api",
+  "properties": {
+    "pricingTier": "Standard",
+    "subPlan": "P1"
+  }
+}
+```
+
+---
+
+## Related Resources
+
+- Built-in policy: **Microsoft Defender for APIs should be enabled**
+- ARM resource type: `Microsoft.Security/pricings`
+- Microsoft Defender for Cloud documentation
+- Azure Policy `DeployIfNotExists` effect


### PR DESCRIPTION
## Summary
 - Add custom Defender for APIs policy at subscription scope
 - Enforce pricingTier=Standard and configurable subPlan (P1-P5)
 - Add README with usage, remediation, and verification guidance

 Closes azure/Microsoft-Defender-for-Cloud#1043