### PR TITLE
Fix subscription retrieval to ensure array format

### DIFF
--- a/Powershell scripts/Microsoft Defender for Cloud - Assets Discovery Scripts/AzureAssetsDiscovery.ps1
+++ b/Powershell scripts/Microsoft Defender for Cloud - Assets Discovery Scripts/AzureAssetsDiscovery.ps1
@@ -60,8 +60,8 @@ try {
 # ============================================================================
 try {
     Write-Host "Scanning for subscriptions (this may take a moment)..." -ForegroundColor Yellow
-    $subscriptions = Get-AzSubscription -TenantId $accountInfo.Tenant.Id
-    if (-not $subscriptions) {
+    $subscriptions = @(Get-AzSubscription -TenantId $accountInfo.Tenant.Id)
+    if ($subscriptions.Count -eq 0) {
         throw "No subscriptions found."
     }
     Write-Host "Found $($subscriptions.Count) subscriptions" -ForegroundColor Yellow


### PR DESCRIPTION
Force subscription retrieval into array in order to accommodate tenants with only one subscription.