### PR TITLE
Fix single-subscription failure in AzureAssetsDiscovery.ps1

### DIFF
--- a/Powershell scripts/Microsoft Defender for Cloud - Assets Discovery Scripts/AzureAssetsDiscovery.ps1
+++ b/Powershell scripts/Microsoft Defender for Cloud - Assets Discovery Scripts/AzureAssetsDiscovery.ps1
@@ -60,8 +60,10 @@ try {
 # ============================================================================
 try {
     Write-Host "Scanning for subscriptions (this may take a moment)..." -ForegroundColor Yellow
-    $subscriptions = Get-AzSubscription -TenantId $accountInfo.Tenant.Id
-    if (-not $subscriptions) {
+    # Force an array so .Count works even when a single subscription is returned
+    # (a lone object has no .Count, which throws under Set-StrictMode).
+    $subscriptions = @(Get-AzSubscription -TenantId $accountInfo.Tenant.Id)
+    if ($subscriptions.Count -eq 0) {
         throw "No subscriptions found."
     }
     Write-Host "Found $($subscriptions.Count) subscriptions" -ForegroundColor Yellow


### PR DESCRIPTION
## Problem
When a tenant has exactly **one** subscription, `Get-AzSubscription` returns a single object rather than a collection. Under `Set-StrictMode -Version Latest` (enabled in this script), accessing `.Count` on that lone object throws:

> The property 'Count' cannot be found on this object. Verify that the property exists.

This caused the script to fail during the GET SUBSCRIPTIONS step for single-subscription tenants:

> Write-Error: Failed to retrieve subscriptions. Error: The property 'Count' cannot be found on this object.

## Fix
Wrap the result of `Get-AzSubscription` in the array subexpression `@(...)` so `` is always an array (`.Count` is then valid for 0, 1, or many), and check `.Count -eq 0` for the empty case.

## Scope
Single-file, 4 insertions / 2 deletions in `AzureAssetsDiscovery.ps1`. No behavior change for multi-subscription tenants. Script parses cleanly (`[Parser]::ParseFile` reports no syntax errors).